### PR TITLE
Add a explanation about heading order and examples

### DIFF
--- a/source/lesson-1-html-and-css.html.md.erb
+++ b/source/lesson-1-html-and-css.html.md.erb
@@ -178,7 +178,33 @@ Headings come in 6 levels:
 <h6>Heading</h6>
 ```
 
-A h1 defines the most important heading whereas a h6 defines the least important.
+A h1 defines the most important heading whereas a h6 defines the least important. 
+
+It's important to not skip one or more heading levels. This is because screenreaders can jump from heading to heading; leaving a heading level out may lead to a user being confused.
+
+Don't:
+
+```html
+<h1>Heading 1</h1>
+<h3>Heading 3</h3><!-- Oh no! A h3 shouldn't be the next heading after a h1 -->
+<h4>Heading 4</h4>
+```
+
+Do:
+```html
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h2>
+```
+
+Headings can skip a level when _increasing_:
+```html
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h2>
+<h4>Heading 4</h4>
+<h2>Heading 2</h2><!-- This h2 following a h4 is okay -->
+```
 
 #### Task 3: add a heading
 

--- a/source/lesson-1-html-and-css.html.md.erb
+++ b/source/lesson-1-html-and-css.html.md.erb
@@ -180,9 +180,10 @@ Headings come in 6 levels:
 
 A `h1` defines the most important heading whereas a `h6` defines the least important. 
   
+Headings should go from `h1` to `h6` in order - always start from `<h1>`, next use `<h2>`, and so on.
+  
 It's important to not skip one or more heading levels - this is because screenreaders can jump from heading to heading and leaving a heading level out may lead to a user being confused.
 
-Headings should go from `h1` to `h6` in order, but headings can jump levels from `h6` to `h1`.  
   
 Don't:
 
@@ -201,7 +202,7 @@ Do:
 <h3>Heading 3</h3>
 ```
 
-Headings can skip a level when going back up:
+Headings can skip a level when going back up to a more important heading level:
 ```html
 <h1>Heading 1</h1>
 <h2>Heading 2</h2>

--- a/source/lesson-1-html-and-css.html.md.erb
+++ b/source/lesson-1-html-and-css.html.md.erb
@@ -169,7 +169,7 @@ You can write text like this
 
 Headings come in 6 levels:
 
-```
+```html
 <h1>Heading</h1>
 <h2>Heading</h2>
 <h3>Heading</h3>
@@ -178,10 +178,12 @@ Headings come in 6 levels:
 <h6>Heading</h6>
 ```
 
-A h1 defines the most important heading whereas a h6 defines the least important. 
+A `h1` defines the most important heading whereas a `h6` defines the least important. 
+  
+It's important to not skip one or more heading levels - this is because screenreaders can jump from heading to heading and leaving a heading level out may lead to a user being confused.
 
-It's important to not skip one or more heading levels. This is because screenreaders can jump from heading to heading; leaving a heading level out may lead to a user being confused.
-
+Headings should go from `h1` to `h6` in order, but headings can jump levels from `h6` to `h1`.  
+  
 Don't:
 
 ```html
@@ -194,16 +196,19 @@ Do:
 ```html
 <h1>Heading 1</h1>
 <h2>Heading 2</h2>
-<h3>Heading 3</h2>
+<h2>Another heading 2</h2><!-- A heading can follow a heading of the same level -->
+<h2>Yet another heading 2</h2>
+<h3>Heading 3</h3>
 ```
 
-Headings can skip a level when _increasing_:
+Headings can skip a level when going back up:
 ```html
 <h1>Heading 1</h1>
 <h2>Heading 2</h2>
 <h3>Heading 3</h2>
 <h4>Heading 4</h4>
-<h2>Heading 2</h2><!-- This h2 following a h4 is okay -->
+<h2>Another heading 2</h2><!-- This h2 following a h4 is okay -->
+<h3>Another heading 3</h3>
 ```
 
 #### Task 3: add a heading


### PR DESCRIPTION
The order of headings is really important for screen readers as users can use headings to jump around the page from section to section. Skipping levels can lead to a user confusion.

Although it does add some complication, I think it's important to include this at the beginning to help convey that the semantic meaning of an element is important. Plus to help embed the idea that browsers aren't only for showing things - they can read things too.

I've used [MDN page on headings](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#Accessibility_concerns) as the main source. I left out a link to it in the docs as I thought that could complicate things, since that page goes deeper than needed here.