### PR TITLE
Remove unnecessary parentheses from method calls

### DIFF
--- a/examples/lesson-3-ruby-on-the-web/barking-permit-server.rb
+++ b/examples/lesson-3-ruby-on-the-web/barking-permit-server.rb
@@ -16,11 +16,11 @@ server.mount_proc("/home") do |request, response|
       sub("DOG_NAME", dog_name).
       sub("DOG_AGE_HUMAN_YEARS", dog_age).
       sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s).
-      sub("PERMIT_ISSUED_ON", Date.today().strftime("%d/%m/%Y")).
-      sub("PERMIT_VALID_UNTIL", (Date.today() + 1000).strftime("%d/%m/%Y"))
+      sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y")).
+      sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
   else
     response.body = File.read("index.html")
   end
 end
 
-server.start()
+server.start

--- a/examples/lesson-3-ruby-on-the-web/birthday.rb
+++ b/examples/lesson-3-ruby-on-the-web/birthday.rb
@@ -11,5 +11,5 @@ server.mount_proc("/") do |request, response|
   @
 end
 
-server.start()
+server.start
 

--- a/examples/lesson-3-ruby-on-the-web/hello-world-server.rb
+++ b/examples/lesson-3-ruby-on-the-web/hello-world-server.rb
@@ -6,4 +6,4 @@ server.mount_proc("/") do |request, response|
   response.body = "Hello browser!"
 end
 
-server.start()
+server.start

--- a/source/lesson-2-ruby-and-the-command-line.html.md.erb
+++ b/source/lesson-2-ruby-and-the-command-line.html.md.erb
@@ -337,15 +337,15 @@ again. It would be nice if we could give a particular task a name, and run it
 just by calling its name.
 
 In Ruby we do this with *methods*, and there are lots of them already built
-into the language. One example is `rand()`, which generates a random number:
+into the language. One example is `rand`, which generates a random number:
 
 ```
-irb(main):025:0> rand()
+irb(main):025:0> rand
 => 0.11487911496307956
 ```
 
 If we want to generate a random number less than a particular number, we can
-provide our maximum to `rand()` as an "argument":
+provide our maximum to `rand` as an "argument":
 
 ```
 irb(main):026:0> rand(100)
@@ -357,9 +357,9 @@ irb(main):027:0> rand(100)
 You can also call some methods on *things* by using a `.` like this:
 
 ```
-irb(main):028:0> "make me louder".upcase()
+irb(main):028:0> "make me louder".upcase
 => "MAKE ME LOUDER"
-irb(main):029:0> "em esrever".reverse()
+irb(main):029:0> "em esrever".reverse
 => "reverse me"
 ```
 
@@ -377,7 +377,7 @@ Decode this top secret, encrypted message:
 <summary>Answer</summary>
 
 ```
-irb(main):030:0> "!gniog peeK !llew repus gniod er'uoY".reverse()
+irb(main):030:0> "!gniog peeK !llew repus gniod er'uoY".reverse
 => "You're doing super well! Keep going!"
 ```
 
@@ -406,7 +406,7 @@ all of our user input and output. When we want to show something to the user
 we need to explicitly say so, and likewise, when we want some input from the
 user we have to explicitly ask for it.
 
-Ruby provides a `puts()` method (put string) and a `gets()` method (get
+Ruby provides a `puts` method (put string) and a `gets` method (get
 string).
 
 * `puts` - prints a string to the command line
@@ -420,7 +420,7 @@ Add the following to your `hello.rb` file, save it, and run it with `ruby hello.
 
 ```ruby
 puts("What is your name?")
-name = gets()
+name = gets
 puts("Hello #{name}")
 ```
 
@@ -454,7 +454,7 @@ so Ruby doesn't know what to do.
 
 Create a new script called `reverse.rb` in your text editor.
 
-Use `gets()`, `.reverse()` and `puts()` to get a string from the user,
+Use `gets`, `.reverse` and `puts` to get a string from the user,
 reverse it, and print it.
 
 <details>
@@ -462,9 +462,9 @@ reverse it, and print it.
 
 ```ruby
 puts("Enter a string to reverse: ")
-input = gets()
+input = gets
 puts("Your string reversed is: ")
-puts(input.reverse())
+puts(input.reverse)
 ```
 
 </details>
@@ -473,21 +473,21 @@ puts(input.reverse())
 
 Create a new script called `multiply.rb` in your text editor.
 
-Note that `gets()` gets the user input as a `string`. In Ruby strings and
+Note that `gets` gets the user input as a `string`. In Ruby strings and
 numbers are *not the same* (`"42" != 42`).
 
 When you need to ask the user for a number you must ask them for a string and
-then convert it into a number using `.to_i()` like so:
+then convert it into a number using `.to_i` like so:
 
 ```ruby
-user_input_as_string = gets()
-user_input_as_number = user_input_as_string.to_i()
+user_input_as_string = gets
+user_input_as_number = user_input_as_string.to_i
 ```
 
-The `i` in `.to_i()` stands for "integer" which is fancy way of saying
+The `i` in `.to_i` stands for "integer" which is fancy way of saying
 "whole number".
 
-Use `gets()`, `.to_i()` and `puts()` to get two strings from the user,
+Use `gets`, `.to_i` and `puts` to get two strings from the user,
 converts them to numbers, multiplies them together and prints the result.
 
 <details>
@@ -495,11 +495,11 @@ converts them to numbers, multiplies them together and prints the result.
 
 ```ruby
 puts("Enter the first number:")
-x_string = gets()
-x_number = x_string.to_i()
+x_string = gets
+x_number = x_string.to_i
 puts("Enter the second number:")
-y_string = gets()
-y_number = y_string.to_i()
+y_string = gets
+y_number = y_string.to_i
 puts("#{x_number} * #{y_number} = #{x_number * y_number}")
 ```
 
@@ -545,7 +545,7 @@ them as you want.
 
 #### Task 10: Create a script that converts human years to dog years
 
-Create a script called `dog-years.rb`. Use `puts()`, `gets()` and `.to_i()`
+Create a script called `dog-years.rb`. Use `puts`, `gets` and `.to_i`
 to ask the user how old their dog is.
 
 Assuming that dogs age faster than humans, and that there are seven "dog
@@ -562,8 +562,8 @@ Call the method in your script, and print the result.
 
 ```ruby
 puts("How old is your dog in human years?")
-age_human_years_string = gets()
-age_human_years_number = age_human_years_string.to_i()
+age_human_years_string = gets
+age_human_years_number = age_human_years_string.to_i
 
 def convert_to_dog_years(age)
   return age * 7
@@ -592,25 +592,25 @@ how they work. (If you get stuck in a loop in `irb` you can escape it by
 pressing `ctrl + c`):
 
 ```ruby
-5.times() do
+5.times do
   puts("Odelay!")
 end
 ```
 
 ```ruby
-10.times() do |i|
+10.times do |i|
   puts("#{10 - i} green bottles, hanging on the wall,")
   puts("#{10 - i} green bottles, hanging on the wall,")
   puts("And if one green bottle should accidentally fall,")
   puts("There'll be #{9 - i} green bottles hanging on the wall.")
-  puts()
+  puts
 end
 ```
 
 ```ruby
-loop() do
+loop do
   puts("What's your name?")
-  name = gets()
+  name = gets
   puts("Hello #{name} (to exit this infinite loop, press ctrl+c)")
 end
 ```
@@ -632,13 +632,13 @@ by pressing `ctrl + c`.
 <summary>Answer</summary>
 
 ```ruby
-loop() do
+loop do
   puts("Enter the first number:")
-  x_string = gets()
-  x_number = x_string.to_i()
+  x_string = gets
+  x_number = x_string.to_i
   puts("Enter the second number:")
-  y_string = gets()
-  y_number = y_string.to_i()
+  y_string = gets
+  y_number = y_string.to_i
   puts("#{x_number} * #{y_number} = #{x_number * y_number}")
 end
 ```
@@ -652,7 +652,7 @@ some condition. To do this, we can use the `if` statement, like so:
 
 ```ruby
 puts("What is your name?")
-name = gets()
+name = gets
 if name.include?("r")
   puts("Hi #{name} - you sound like a pretty cool person")
 else
@@ -662,7 +662,7 @@ end
 
 An `if` statement takes a "condition" (something that evaluates
 to `true` or `false`). You can use things like `==` (equals), `<` (less than),
-or methods like `.include?()` (like we did in the example).
+or methods like `.include?` (like we did in the example).
 
 If the condition is true Ruby will run the lines of code between
 the `if` and the `else`, otherwise Ruby will run the lines of code between
@@ -702,7 +702,7 @@ Here's a rough plan of how to implement this:
 
 * create a `score` variable to keep track of the users score
 * in a loop that happens 4 times
-  * generate two numbers between 1 and 12 using `rand()` and assign them to variables
+  * generate two numbers between 1 and 12 using `rand` and assign them to variables
   * print a message to the user asking them to multiply the numbers together
   * get the user's answer and covert it to a number (using `.to_i`)
   * compare the user's answer to the answer Ruby thinks is correct
@@ -717,13 +717,13 @@ the work to make the loop easier to read.
 <summary>Answer</summary>
 
 ```ruby
-def multiplication_challenge()
+def multiplication_challenge
   x = rand(12) + 1
   y = rand(12) + 1
-  
+
   print("What is #{x} multiplied by #{y} ? ")
-  user_input = gets()
-  user_input_as_a_number = user_input.to_i()
+  user_input = gets
+  user_input_as_a_number = user_input.to_i
 
   correct_answer = x * y
   if user_input_as_a_number == correct_answer
@@ -741,13 +741,13 @@ score = 0
 
 puts("Times tables challenge")
 puts("----------------------")
-puts()
+puts
 puts("You will be asked #{number_of_rounds} questions.")
 puts("Press enter to start...")
-gets()
+gets
 
-number_of_rounds.times() do |i|
-  if multiplication_challenge()
+number_of_rounds.times do |i|
+  if multiplication_challenge
     score = score + 1
   end
 end

--- a/source/lesson-3-ruby-on-the-web.html.md.erb
+++ b/source/lesson-3-ruby-on-the-web.html.md.erb
@@ -32,9 +32,9 @@ You'll have a basic understanding of how web applications work, and a good found
 
 ### Using `require` to access other Ruby modules
 
-In lesson 2 we used a number of built-in Ruby methods, like `rand()` (to get
-a random number), `.reverse()` (to reverse a string), `gets()` and
-`puts()` (to read and write strings from the command line).
+In lesson 2 we used a number of built-in Ruby methods, like `rand` (to get
+a random number), `.reverse` (to reverse a string), `gets` and
+`puts` (to read and write strings from the command line).
 
 These methods are so useful that they live in the core of Ruby, so you can
 always call them.
@@ -49,7 +49,7 @@ script. For example:
 ```
 irb(main):001:0> require("date")
 => true
-irb(main):002:0> Date.today()
+irb(main):002:0> Date.today
 => #<Date: 2019-05-30 ((2458633j,0s,0n),+0s,2299161j)>
 ```
 
@@ -60,12 +60,12 @@ Ruby's date type makes doing things like adding days to a date much easier
 are in a month and so on).
 
 ```
-irb(main):003:0> one_thousand_days_in_the_future = Date.today() + 1000
+irb(main):003:0> one_thousand_days_in_the_future = Date.today + 1000
 => #<Date: 2022-02-23 ((2459633j,0s,0n),+0s,2299161j)>
 ```
 
-The `.today()` method gets today's date, but you can also create dates for
-other days using `.new()`:
+The `.today` method gets today's date, but you can also create dates for
+other days using `.new`:
 
 ```
 irb(main):004:0> Date.new(2022, 2, 23)
@@ -74,15 +74,15 @@ irb(main):004:0> Date.new(2022, 2, 23)
 
 Because different cultures represent dates in different ways (e.g. Japan use
 2019-05-30, the USA use 05/30/2019 and the UK use 30/05/2019), there's a
-special method for formatting dates as strings called `.strftime()`. It takes
+special method for formatting dates as strings called `.strftime`. It takes
 a "format" string as an argument specifying how to show the date:
 
 ```
-irb(main):005:0> japan_format = Date.today().strftime("%Y-%m-%d")
+irb(main):005:0> japan_format = Date.today.strftime("%Y-%m-%d")
 => "2019-05-30"
-irb(main):006:0> usa_format = Date.today().strftime("%m/%d/%Y")
+irb(main):006:0> usa_format = Date.today.strftime("%m/%d/%Y")
 => "05/30/2019"
-irb(main):007:0> uk_format = Date.today().strftime("%d/%m/%Y")
+irb(main):007:0> uk_format = Date.today.strftime("%d/%m/%Y")
 => "30/05/2019"
 ```
 
@@ -116,10 +116,10 @@ irb(main):003:0> birthday.strftime("%A")
 ### Using `File` to read files in Ruby
 
 Sometimes it's nice to be able to store things in files, and read these files
-using Ruby so we can do something with the contents. Ruby has a `File.read()`
+using Ruby so we can do something with the contents. Ruby has a `File.read`
 method that lets us do this.
 
-`File.read()` takes the path to the file as an argument, and returns the
+`File.read` takes the path to the file as an argument, and returns the
 contents of the file as a string.
 
 ```
@@ -128,23 +128,23 @@ irb(main):004:0> File.read("/Users/your-username/Desktop/lesson-1-html-and-css/i
 ```
 
 We can work with the contents using all the string methods (like
-`.reverse()`) we've already seen.
+`.reverse`) we've already seen.
 
-There are lots of other useful methods like `.size()` (which returns how many
-characters there are in the string), and `.sub()` (which takes two arguments,
+There are lots of other useful methods like `.size` (which returns how many
+characters there are in the string), and `.sub` (which takes two arguments,
 and substitutes the first occurence of the first string with the second).
 
 ```
 irb(main):005:0> "Cats are the best".sub("Cat", "Dog")
 => "Dogs are the best"
-irb(main):006:0> "Dogs are the best".size()
+irb(main):006:0> "Dogs are the best".size
 => 17
 ```
 
 #### Task 2: count the characters in a file
 
-We created a file in `lesson-1-html-and-css/index.html`. Use `File.read()`
-and `.size()` to work out how many characters there are in the file.
+We created a file in `lesson-1-html-and-css/index.html`. Use `File.read`
+and `.size` to work out how many characters there are in the file.
 
 > In Finder you can copy the path to a directory by right clicking, holding
 down the option key (`⌥`), and choosing *Copy "Directory" as Pathname*.
@@ -157,7 +157,7 @@ the path for you.
 ```
 irb(main):006:0> file = File.read("/Users/your-username/Desktop/lesson-1-html-and-css/index.html")
 => "<!doctype html>\n<html>...
-irb(main):007:0> file.size()
+irb(main):007:0> file.size
 1260
 ```
 
@@ -253,12 +253,12 @@ lesson-3-ruby-on-the-web
 
 ### Hello WEBrick!
 
-Earlier we `require()`'d `"date"` so we could do some things with dates which
+Earlier we `require`'d `"date"` so we could do some things with dates which
 aren't in the core ruby language. Similarly, we can require a thing called
 `"webrick"` which allows us to build HTTP servers.
 
 We can use WEBrick to create a new server by calling the
-`WEBrick::HTTPServer.new()` method like this:
+`WEBrick::HTTPServer.new` method like this:
 
 ```ruby
 require("webrick")
@@ -271,7 +271,7 @@ worry about it - at some point you'll learn about modules, classes, and named
 arguments and it will all make sense.
 
 The `server` lets us respond to HTTP requests in any way we like. We can use
-the `.mount_proc()` method to attach a block of Ruby code to a particular request like this:
+the `.mount_proc` method to attach a block of Ruby code to a particular request like this:
 
 ```ruby
 server.mount_proc("/home") do |request, response|
@@ -280,10 +280,10 @@ server.mount_proc("/home") do |request, response|
 end
 ```
 
-`.mount_proc()` is a bit like `.times()` from lesson 2:
+`.mount_proc` is a bit like `.times` from lesson 2:
 
 ```ruby
-10.times() do |i|
+10.times do |i|
   puts("#{10 - i} green bottles, hanging on the wall,")
   # ...
 end
@@ -293,11 +293,11 @@ only instead of running the block 10 times straight away, WEBrick will run
 the block every time a request is made to the `/home` path.
 
 The final thing we need to do to make the server work is start it, which we
-do by calling the `.start()` method after we've made all our calls to
-`.mount_proc()`:
+do by calling the `.start` method after we've made all our calls to
+`.mount_proc`:
 
 ```ruby
-server.start()
+server.start
 ```
 
 #### Task 5: Create a "hello world" server
@@ -314,7 +314,7 @@ server.mount_proc("/home") do |request, response|
   response.body = "Hello browser!"
 end
 
-server.start()
+server.start
 ```
 
 * On the command line, change directory into `lesson-3-ruby-on-the-web` using `cd`
@@ -367,7 +367,7 @@ end
 It can get difficult to maintain if we put all our HTML in ruby strings like
 we did in the example above. It would be much nicer if we could have our HTML
 in html files and our Ruby in ruby files. Fortunately, we can achieve this
-with `File.read()`:
+with `File.read`:
 
 
 ```ruby
@@ -398,7 +398,7 @@ server.mount_proc("/home") do |request, response|
   response.body = File.read("index.html")
 end
 
-server.start()
+server.start
 ```
 
 </details>
@@ -456,7 +456,7 @@ server.mount_proc("/home") do |request, response|
   end
 end
 
-server.start()
+server.start
 ```
 
 </details>
@@ -472,7 +472,7 @@ input?
 
 Templating lets us take a file and substitute placeholders with values of our
 choice. There are lots of fancy templating languages out there, but for us
-Ruby's `.sub()` method will be good enough.
+Ruby's `.sub` method will be good enough.
 
 Imagine we had some HTML in a file called `fruits.html`:
 
@@ -558,8 +558,8 @@ Add the following HTML to the file (it's fine to copy-paste this):
 Update `barking-permit-server.rb` so that when `request.query["dog-name"]` is
 set, `response.body` is set to `File.read("barking-permit-template.html")`.
 
-Use `.sub()` to replace `DOG_NAME` with `request.query["dog-name"]` and a
-second `.sub()` to replace `DOG_AGE_HUMAN_YEARS` with `request.query["dog-age"]`.
+Use `.sub` to replace `DOG_NAME` with `request.query["dog-name"]` and a
+second `.sub` to replace `DOG_AGE_HUMAN_YEARS` with `request.query["dog-age"]`.
 
 Run the server with `ruby barking-permit-server.rb`, visit [http://localhost:8080/home](http://localhost:8080/home) and submit the form.
 
@@ -585,7 +585,7 @@ server.mount_proc("/home") do |request, response|
   end
 end
 
-server.start()
+server.start
 ```
 
 </details>
@@ -611,7 +611,7 @@ is valid for.
   * Age (dog years) should be the Age in human years multiplied by 7 (as per lesson 2)
   * Issued on should be today's date, formatted as `Day/Month/Year`
   * Valid until should be today's date + 1,000 days (arbitrarily), formatted as `Day/Month/Year`
-* Use three more `.sub()`s to replace the placeholders
+* Use three more `.sub`s to replace the placeholders
 * Run the server with `ruby barking-permit-server.rb`, visit [http://localhost:8080/home](http://localhost:8080/home) and submit the form.
 * When you're done, stop the server with `CTRL + C`.
 
@@ -637,21 +637,21 @@ server.mount_proc("/home") do |request, response|
       sub("DOG_NAME", dog_name).
       sub("DOG_AGE_HUMAN_YEARS", dog_age).
       sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s).
-      sub("PERMIT_ISSUED_ON", Date.today().strftime("%d/%m/%Y")).
-      sub("PERMIT_VALID_UNTIL", (Date.today() + 1000).strftime("%d/%m/%Y"))
+      sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y")).
+      sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
   else
     response.body = File.read("index.html")
   end
 end
 
-server.start()
+server.start
 ```
 
 </details>
 
 ### Warning: security!
 
-We've deliberately cut some corners by using `.sub()` for our templating
+We've deliberately cut some corners by using `.sub` for our templating
 which would cause security problems in a production application.
 
 In particular, mixing user input and HTML can leave us vulnerable to a thing


### PR DESCRIPTION
Typically in Ruby we don't have parentheses at the end of method calls if no
arguments are being passed so this removes them.  See
https://github.com/rubocop-hq/ruby-style-guide#method-definition-parentheses.