### PR TITLE
Remove explicit returns

### DIFF
--- a/source/lesson-2-ruby-and-the-command-line.html.md.erb
+++ b/source/lesson-2-ruby-and-the-command-line.html.md.erb
@@ -534,8 +534,7 @@ In Ruby a method definition looks like this:
 
 ```ruby
 def method_name(argument)
-  result = "some value"
-  return result
+  "some value"
 end
 ```
 
@@ -566,7 +565,7 @@ age_human_years_string = gets()
 age_human_years_number = age_human_years_string.to_i()
 
 def convert_to_dog_years(age)
-  return age * 7
+  age * 7
 end
 
 age_dog_years = convert_to_dog_years(age_human_years_number)
@@ -728,11 +727,10 @@ def multiplication_challenge()
   correct_answer = x * y
   if user_input_as_a_number == correct_answer
     puts(":) correct!")
-    return true
+    true
   else
     puts(":( oops!")
     puts("The answer was #{correct_answer}")
-    return false
   end
 end
 

--- a/source/lesson-3-ruby-on-the-web.html.md.erb
+++ b/source/lesson-3-ruby-on-the-web.html.md.erb
@@ -623,7 +623,7 @@ require("webrick")
 require("date")
 
 def convert_to_dog_years(age_human_years)
-  return age_human_years * 7
+  age_human_years * 7
 end
 
 server = WEBrick::HTTPServer.new(Port: 8080, DocumentRoot: './public')


### PR DESCRIPTION
We don't need to explicitly return many of the values in these examples; Ruby
returns them anyway.  See
https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return