### PR TITLE
Ignore "app already exists" from cloud foundry

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -13,13 +13,13 @@ fi
 bundle exec middleman build
 
 cf t -o govuk-paas -s learn-to-code
-cf v3-create-app learn-to-code
+cf v3-create-app learn-to-code || true
 cf v3-apply-manifest -f manifest.yml
 cf v3-zdt-push learn-to-code -p build --wait-for-deploy-complete
 
 (
 cd "examples/lesson-1-html-and-css/"
-cf v3-create-app apply-for-a-barking-permit
+cf v3-create-app apply-for-a-barking-permit || true
 cf v3-apply-manifest -f manifest.yml
 cf v3-zdt-push apply-for-a-barking-permit --wait-for-deploy-complete
 )


### PR DESCRIPTION
It looks like the behaviour of v3-create-app has changed since I wrote
this script - it used to silently ignore being called a second time for
the same app, now it errors.

It should be safe to just ignore the error, so using `|| true` to do
that.