### PR TITLE
Move dots to the same line as `.sub()` calls

### DIFF
--- a/examples/lesson-3-ruby-on-the-web/barking-permit-server.rb
+++ b/examples/lesson-3-ruby-on-the-web/barking-permit-server.rb
@@ -12,12 +12,12 @@ server.mount_proc("/home") do |request, response|
   dog_age = request.query["dog-age"]
 
   if dog_name
-    response.body = File.read("barking-permit-template.html").
-      sub("DOG_NAME", dog_name).
-      sub("DOG_AGE_HUMAN_YEARS", dog_age).
-      sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s).
-      sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y")).
-      sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
+    response.body = File.read("barking-permit-template.html")
+      .sub("DOG_NAME", dog_name)
+      .sub("DOG_AGE_HUMAN_YEARS", dog_age)
+      .sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s)
+      .sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y"))
+      .sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
   else
     response.body = File.read("index.html")
   end

--- a/source/lesson-4-ruby-on-the-web.html.md.erb
+++ b/source/lesson-4-ruby-on-the-web.html.md.erb
@@ -351,9 +351,9 @@ Imagine we had some HTML in a file called `fruits.html`:
 We could load this file up, and then substitute the placeholders like this:
 
 ```ruby
-File.read("fruits.html").
-  sub("FAVOURITE_FRUIT_NAME", "Banana").
-  sub("FAVOURITE_FRUIT_REASON", "easy to peel")
+File.read("fruits.html")
+  .sub("FAVOURITE_FRUIT_NAME", "Banana")
+  .sub("FAVOURITE_FRUIT_REASON", "easy to peel")
 ```
 
 Which would return:
@@ -443,9 +443,9 @@ server.mount_proc("/home") do |request, response|
   dog_age = request.query["dog-age"]
 
   if dog_name
-    response.body = File.read("barking-permit-template.html").
-      sub("DOG_NAME", dog_name).
-      sub("DOG_AGE_HUMAN_YEARS", dog_age)
+    response.body = File.read("barking-permit-template.html")
+      .sub("DOG_NAME", dog_name)
+      .sub("DOG_AGE_HUMAN_YEARS", dog_age)
   else
     response.body = File.read("index.html")
   end
@@ -499,12 +499,12 @@ server.mount_proc("/home") do |request, response|
   dog_age = request.query["dog-age"]
 
   if dog_name
-    response.body = File.read("barking-permit-template.html").
-      sub("DOG_NAME", dog_name).
-      sub("DOG_AGE_HUMAN_YEARS", dog_age).
-      sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s).
-      sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y")).
-      sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
+    response.body = File.read("barking-permit-template.html")
+      .sub("DOG_NAME", dog_name)
+      .sub("DOG_AGE_HUMAN_YEARS", dog_age)
+      .sub("DOG_AGE_DOG_YEARS", convert_to_dog_years(dog_age.to_i).to_s)
+      .sub("PERMIT_ISSUED_ON", Date.today.strftime("%d/%m/%Y"))
+      .sub("PERMIT_VALID_UNTIL", (Date.today + 1000).strftime("%d/%m/%Y"))
   else
     response.body = File.read("index.html")
   end


### PR DESCRIPTION
I think originally I did this with the dots at the end of the lines to
make it "more obvious" to the reader that the line wasn't finished (and
that the next line followed on from it).

I've seen a couple of people get confused by it though - they don't see
the dot, and instead do something like:

```
response.body = File.read("barking-permit-template.html")
  sub("DOG_NAME", dog_name)
  sub("DOG_AGE_HUMAN_YEARS", dog_age).
```

... which results in `object:Main has no method sub` or something like
that. Which is confusing.

I think it's a little bit easier to spot the dot if it's on the
beginning of the line.

Still confusing, but hey, it's coding. It's famously confusing.

At least this is a possible opportunity to show the difference between
top level methods and instance methods.