### PR TITLE
BAU: Fix missing bundler error message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Build
       run: |
+        gem install bundler -v 1.17.2
         bundle install
         bundle exec middleman build
 


### PR DESCRIPTION
This change adds a command line to install a missing specific version of bundler. This will resolve the following error message taken from GitHub Action.

/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/rubygems.rb:277:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by your /home/runner/work/learn-to-code/learn-to-code/Gemfile.lock. (Gem::GemNotFoundException)

I have tested it in GitHub Action. It is working fine.