### PR TITLE
Update workflow to use ruby/setup-ruby image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1 # version read from `.ruby-version` file
       with:
-        version: '2.7'
+        bundler-cache: true
 
     - name: Install the CF CLI
       run: |


### PR DESCRIPTION
## What

Change the setup ruby image from [actions/setup-ruby](https://github.com/actions/setup-ruby) to [ruby/setup-ruby](https://github.com/ruby/setup-ruby).

## Why 
This warning message was being thrown by the actions/setup-ruby image:
> Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use ruby-version instead

(https://github.com/alphagov/learn-to-code/actions/runs/488260637)

Rather than change the parameter to `ruby-version`, this changes the image to the [ruby/setup-ruby image](https://github.com/ruby/setup-ruby) as this image reads the [ruby version from the `.ruby-version` file][1] instead of needing the version as a parameter (bonus, as the version is only in one place) and has [built in bundle caching][2] for faster builds.

[1]: https://github.com/ruby/setup-ruby#usage
[2]: https://github.com/ruby/setup-ruby#caching-bundle-install-automatically