### PR TITLE
Rearrange workflow to check the repo out first

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
+    - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1 # version read from `.ruby-version` file
       with:
         bundler-cache: true
@@ -21,7 +21,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cf7-cli
 
-    - uses: actions/checkout@master
     - name: Build
       run: |
         bundle install


### PR DESCRIPTION
## What
Rearranges the workflow order to checkout the repository before all other steps. 

Sets the `actions/checkout` step to v2 to avoid automatically using any breaking changes.

## Why 
The `ruby/setup-ruby` step of the workflow needs the repository checked out first so it can read the `.ruby-version` file to see which version of ruby should be set up.

See #44 for 💥