### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1 # version read from `.ruby-version` file
       with:
         bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  pull_request:
 
 jobs:
   build:
@@ -27,6 +28,7 @@ jobs:
         bundle exec middleman build
 
     - name: Deploy
+      if: ${{ github.ref == 'refs/heads/master' }}
       env:
         CF_USERNAME: richard.towers+learn-to-code-deployer@digital.cabinet-office.gov.uk
         CF_PASSWORD: ${{ secrets.PAAS_LEARN_TO_CODE_DEPLOYER_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,10 @@ jobs:
         bundler-cache: true
 
     - name: Install the CF CLI
+      # At time of writing, https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key gives an HTTP 403 unless the user agent is set to that of a browser (in this case, Safari)
       run: |
-        wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+        wget -q --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15" https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
+        sudo apt-key add cli.cloudfoundry.org.key
         echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
         sudo apt-get update
         sudo apt-get install -y cf7-cli


### PR DESCRIPTION
For some reason, requests to `https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key` currently get an HTTP 403 if the user agent identifies itself as `wget` or `curl`. I've added a hacky workaround by forcing `wget` to identify itself as Safari 🤮

Piping the output of `wget` directly into `apt-key` causes the error to get swallowed, so I've also split this out into 2 lines.

Finally, Node.js 12 actions are deprecated, so I've upgraded `actions/checkout` to v3.